### PR TITLE
Swap routing to other platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "big.js": "^5.2.2",
     "decimal.js-light": "^2.5.0",
     "dxswap-core": "git://github.com/levelkdev/dxswap-core.git#v0.3.6",
+    "dxswap-periphery": "git://github.com/levelkdev/dxswap-periphery.git#v0.3.7",
     "jsbi": "^3.1.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dxswap-sdk",
   "license": "AGPL-3.0-or-later",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "An SDK for building applications on top of DXswap.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,12 @@ export enum Rounding {
   ROUND_UP
 }
 
+export enum SupportedPlatform {
+  SWAPR,
+  UNISWAP,
+  SUSHISWAP
+}
+
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 export const FACTORY_ADDRESS: { [chainId: number]: string } = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,10 +10,7 @@ export type BigintIsh = JSBI | bigint | string
 
 export enum ChainId {
   MAINNET = 1,
-  ROPSTEN = 3,
   RINKEBY = 4,
-  GÖRLI = 5,
-  KOVAN = 42,
   ARBITRUM_TESTNET_V3 = 79377087078960,
   SOKOL = 77,
   XDAI = 100

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,10 @@ export type BigintIsh = JSBI | bigint | string
 
 export enum ChainId {
   MAINNET = 1,
+  ROPSTEN = 3,
   RINKEBY = 4,
+  GÖRLI = 5,
+  KOVAN = 42,
   ARBITRUM_TESTNET_V3 = 79377087078960,
   SOKOL = 77,
   XDAI = 100

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,20 @@ import PERMISSIVE_MULTICALL_ABI from './abis/PermissiveMulticall.json'
 import STAKING_REWARDS_FACTORY_ABI from './abis/staking-rewards-distribution-factory.json'
 import STAKING_REWARDS_DISTRIBUTION_ABI from './abis/staking-rewards-distribution.json'
 import TOKEN_REGISTRY_ABI from './abis/token-registry.json'
-import { rinkeby, mainnet, arbitrumTestnetV3, sokol, xdai } from 'dxswap-core/.contracts.json'
+import {
+  rinkeby as coreRinkeby,
+  mainnet as coreMainnet,
+  arbitrumTestnetV3 as coreArbitrumTestnetV3,
+  sokol as coreSokol,
+  xdai as coreXDai
+} from 'dxswap-core/.contracts.json'
+import {
+  rinkeby as peripheryRinkeby,
+  mainnet as peripheryMainnet,
+  arbitrumTestnetV3 as peripheryArbitrumTestnetV3,
+  sokol as peripherySokol,
+  xdai as peripheryXDai
+} from 'dxswap-periphery/.contracts.json'
 
 // exports for external consumption
 export type BigintIsh = JSBI | bigint | string
@@ -27,20 +40,22 @@ export enum Rounding {
   ROUND_UP
 }
 
-export enum SupportedPlatform {
-  SWAPR,
-  UNISWAP,
-  SUSHISWAP
-}
-
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 export const FACTORY_ADDRESS: { [chainId: number]: string } = {
-  [ChainId.MAINNET]: mainnet.factory,
-  [ChainId.RINKEBY]: rinkeby.factory,
-  [ChainId.ARBITRUM_TESTNET_V3]: arbitrumTestnetV3.factory,
-  [ChainId.SOKOL]: sokol.factory,
-  [ChainId.XDAI]: xdai.factory
+  [ChainId.MAINNET]: coreMainnet.factory,
+  [ChainId.RINKEBY]: coreRinkeby.factory,
+  [ChainId.ARBITRUM_TESTNET_V3]: coreArbitrumTestnetV3.factory,
+  [ChainId.SOKOL]: coreSokol.factory,
+  [ChainId.XDAI]: coreXDai.factory
+}
+
+export const ROUTER_ADDRESS: { [chainId in ChainId]?: string } = {
+  [ChainId.RINKEBY]: peripheryRinkeby.router,
+  [ChainId.MAINNET]: peripheryMainnet.router,
+  [ChainId.ARBITRUM_TESTNET_V3]: peripheryArbitrumTestnetV3.router,
+  [ChainId.SOKOL]: peripherySokol.router,
+  [ChainId.XDAI]: peripheryXDai.router
 }
 
 export const STAKING_REWARDS_FACTORY_ADDRESS: { [chainId: number]: string } = {

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -4,5 +4,5 @@ export * from './pair'
 export * from './route'
 export * from './trade'
 export * from './currency'
-
+export * from './routable-platform'
 export * from './fractions'

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -10,6 +10,7 @@ import {
   FACTORY_ADDRESS,
   INIT_CODE_HASH,
   MINIMUM_LIQUIDITY,
+  SupportedPlatform,
   ZERO,
   ONE,
   _30,
@@ -21,12 +22,6 @@ import { sqrt, parseBigintIsh } from '../utils'
 import { InsufficientReservesError, InsufficientInputAmountError } from '../errors'
 import { Token } from './token'
 import { ChainId } from '../constants'
-
-export enum SupportedPlatform {
-  SWAPR,
-  UNISWAP,
-  SUSHISWAP
-}
 
 let PAIR_ADDRESS_CACHE: {
   [supportedPlatform in SupportedPlatform]: {

--- a/src/entities/routable-platform.ts
+++ b/src/entities/routable-platform.ts
@@ -1,0 +1,67 @@
+import { BigintIsh, ChainId, defaultSwapFee, FACTORY_ADDRESS, INIT_CODE_HASH, ROUTER_ADDRESS, _30 } from '../constants'
+
+const UNISWAP_FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
+const SUSHISWAP_FACTORY_ADDRESS = '0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac'
+const HONEYSWAP_FACTORY_ADDRESS = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
+
+const UNISWAP_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+const SUSHISWAP_ROUTER_ADDRESS = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F'
+const HONEYSWAP_ROUTER_ADDRESS = '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77'
+
+/**
+ * A platform to which Swapr can route through.
+ */
+export class RoutablePlatform {
+  public readonly name: string
+  public readonly factoryAddress: { [supportedChainId in ChainId]?: string }
+  public readonly routerAddress: { [supportedChainId in ChainId]?: string }
+  public readonly initCodeHash: string
+  public readonly defaultSwapFee: BigintIsh
+
+  public static readonly SWAPR = new RoutablePlatform(
+    'Swapr',
+    FACTORY_ADDRESS,
+    ROUTER_ADDRESS,
+    INIT_CODE_HASH,
+    defaultSwapFee
+  )
+  public static readonly UNISWAP = new RoutablePlatform(
+    'Uniswap',
+    { [ChainId.MAINNET]: UNISWAP_FACTORY_ADDRESS, [ChainId.RINKEBY]: UNISWAP_FACTORY_ADDRESS },
+    { [ChainId.MAINNET]: UNISWAP_ROUTER_ADDRESS, [ChainId.RINKEBY]: UNISWAP_ROUTER_ADDRESS },
+    '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    _30
+  )
+  public static readonly SUSHISWAP = new RoutablePlatform(
+    'Sushiswap',
+    { [ChainId.MAINNET]: SUSHISWAP_FACTORY_ADDRESS, [ChainId.RINKEBY]: SUSHISWAP_FACTORY_ADDRESS },
+    { [ChainId.MAINNET]: SUSHISWAP_ROUTER_ADDRESS, [ChainId.RINKEBY]: SUSHISWAP_ROUTER_ADDRESS },
+    '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
+    _30
+  )
+  public static readonly HONEYSWAP = new RoutablePlatform(
+    'Honeyswap',
+    { [ChainId.XDAI]: HONEYSWAP_FACTORY_ADDRESS },
+    { [ChainId.XDAI]: HONEYSWAP_ROUTER_ADDRESS },
+    '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93',
+    _30
+  )
+
+  public constructor(
+    name: string,
+    factoryAddress: { [supportedChainId in ChainId]?: string },
+    routerAddress: { [supportedChainId in ChainId]?: string },
+    initCodeHash: string,
+    defaultSwapFee: BigintIsh
+  ) {
+    this.name = name
+    this.factoryAddress = factoryAddress
+    this.routerAddress = routerAddress
+    this.initCodeHash = initCodeHash
+    this.defaultSwapFee = defaultSwapFee
+  }
+
+  public supportsChain(chainId: ChainId): boolean {
+    return !!this.factoryAddress[chainId]
+  }
+}

--- a/src/entities/route.ts
+++ b/src/entities/route.ts
@@ -20,6 +20,10 @@ export class Route {
       'CHAIN_IDS'
     )
     invariant(
+      pairs.every(pair => pair.platform === pairs[0].platform),
+      'PLATFORM'
+    )
+    invariant(
       (input instanceof Token && pairs[0].involvesToken(input)) ||
         (Currency.isNative(input) && pairs[0].involvesToken(Token.getNativeWrapper(pairs[0].chainId))),
       'INPUT'

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant'
 
-import { ChainId, ONE, TradeType, ZERO } from '../constants'
+import { ChainId, ONE, SupportedPlatform, TradeType, ZERO } from '../constants'
 import { sortedInsert } from '../utils'
 import { Currency } from './currency'
 import { CurrencyAmount } from './fractions/currencyAmount'
@@ -137,6 +137,10 @@ export class Trade {
    * The unique identifier of the chain on which the swap is being performed (used to correctly handle the native currency).
    */
   public readonly chainId: ChainId
+  /**
+   * The swap platform this trade will execute on
+   */
+  public readonly platform: SupportedPlatform
 
   /**
    * Constructs an exact in trade with the given amount in and route
@@ -203,6 +207,7 @@ export class Trade {
     )
     this.nextMidPrice = Price.fromRoute(new Route(nextPairs, route.input))
     this.priceImpact = computePriceImpact(route.midPrice, this.inputAmount, this.outputAmount)
+    this.platform = this.route.pairs[0].platform
   }
 
   /**

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant'
 
-import { ChainId, ONE, SupportedPlatform, TradeType, ZERO } from '../constants'
+import { ChainId, ONE, TradeType, ZERO } from '../constants'
 import { sortedInsert } from '../utils'
 import { Currency } from './currency'
 import { CurrencyAmount } from './fractions/currencyAmount'
@@ -9,6 +9,7 @@ import { Percent } from './fractions/percent'
 import { Price } from './fractions/price'
 import { TokenAmount } from './fractions/tokenAmount'
 import { Pair } from './pair'
+import { RoutablePlatform } from './routable-platform'
 import { Route } from './route'
 import { currencyEquals, Token } from './token'
 
@@ -140,7 +141,7 @@ export class Trade {
   /**
    * The swap platform this trade will execute on
    */
-  public readonly platform: SupportedPlatform
+  public readonly platform: RoutablePlatform
 
   /**
    * Constructs an exact in trade with the given amount in and route

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -15,14 +15,14 @@ import {
   FACTORY_ADDRESS,
   PERMISSIVE_MULTICALL_ADDRESS,
   PERMISSIVE_MULTICALL_ABI,
-  SupportedPlatform,
   TOKEN_REGISTRY_ADDRESS,
   DXSWAP_TOKEN_LIST_ID
 } from './constants'
 import { Token } from './entities/token'
 import { Currency } from './entities/currency'
 import { Interface } from '@ethersproject/abi'
-import { TokenList, TokenInfo } from 'entities/token-list'
+import { TokenList, TokenInfo } from './entities/token-list'
+import { RoutablePlatform } from './entities/routable-platform'
 
 const TOKEN_DATA_CACHE: {
   [chainId: number]: { [address: string]: Currency }
@@ -170,7 +170,7 @@ export abstract class Fetcher {
     tokenA: Token,
     tokenB: Token,
     provider = getDefaultProvider(getNetwork(tokenA.chainId)),
-    platform: SupportedPlatform = SupportedPlatform.SWAPR
+    platform: RoutablePlatform = RoutablePlatform.SWAPR
   ): Promise<Pair> {
     invariant(tokenA.chainId === tokenB.chainId, 'CHAIN_ID')
     const address = Pair.getAddress(tokenA, tokenB, platform)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -3,7 +3,7 @@ import { Contract } from '@ethersproject/contracts'
 import { getNetwork } from '@ethersproject/networks'
 import { getDefaultProvider, Provider } from '@ethersproject/providers'
 import { TokenAmount } from './entities/fractions/tokenAmount'
-import { Pair, SupportedPlatform } from './entities/pair'
+import { Pair } from './entities/pair'
 import IDXswapPair from 'dxswap-core/build/IDXswapPair.json'
 import IDXswapFactory from 'dxswap-core/build/IDXswapFactory.json'
 import invariant from 'tiny-invariant'
@@ -15,6 +15,7 @@ import {
   FACTORY_ADDRESS,
   PERMISSIVE_MULTICALL_ADDRESS,
   PERMISSIVE_MULTICALL_ABI,
+  SupportedPlatform,
   TOKEN_REGISTRY_ADDRESS,
   DXSWAP_TOKEN_LIST_ID
 } from './constants'

--- a/test/pair.test.ts
+++ b/test/pair.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, Token, Pair, Fetcher, TokenAmount, JSBI, Price } from '../src'
+import { ChainId, Token, Pair, Fetcher, TokenAmount, JSBI, Price, SupportedPlatform } from '../src'
 import { TEST_TOKENS } from './commons'
 
 describe('Pair', () => {
@@ -17,13 +17,37 @@ describe('Pair', () => {
     it('returns the correct address', () => {
       const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
       const dai = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
-      expect(Pair.getAddress(usdc, dai)).toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
+      expect(Pair.getAddress(usdc, dai, SupportedPlatform.SWAPR)).toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
+    })
+  })
+
+  describe('#getIncorrectAddressFromWrongPlatform', () => {
+    it('returns the incorrect address', () => {
+      const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
+      const dai = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
+      expect(Pair.getAddress(usdc, dai, SupportedPlatform.UNISWAP)).not.toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
+    })
+  })
+
+  describe('#getAddressFromUniswap', () => {
+    it('returns the correct address from Uniswap rather than Swapr', () => {
+      const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
+      const weth = new Token(ChainId.MAINNET, '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 18, 'WETH', 'Wrapped ETH')
+      expect(Pair.getAddress(usdc, weth, SupportedPlatform.UNISWAP)).toEqual('0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc')
+    })
+  })
+
+  describe('#getAddressFromSushiswap', () => {
+    it('returns the correct address from Uniswap rather than Swapr', () => {
+      const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
+      const weth = new Token(ChainId.MAINNET, '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 18, 'WETH', 'Wrapped ETH')
+      expect(Pair.getAddress(usdc, weth, SupportedPlatform.SUSHISWAP)).toEqual('0x397FF1542f962076d0BFE58eA045FfA2d347ACa0')
     })
   })
 
   describe('#fetchData', () => {
     it.skip('returns the correct address', async () => {
-      const pairAddress = Pair.getAddress(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY])
+      const pairAddress = Pair.getAddress(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY], SupportedPlatform.SWAPR)
       const pairData = await Fetcher.fetchPairData(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY])
       expect(pairData.swapFee).toEqual(JSBI.BigInt(10))
       expect(pairData.protocolFeeDenominator).toEqual(JSBI.BigInt(9))

--- a/test/pair.test.ts
+++ b/test/pair.test.ts
@@ -1,4 +1,4 @@
-import { ChainId, Token, Pair, Fetcher, TokenAmount, JSBI, Price, SupportedPlatform } from '../src'
+import { ChainId, Token, Pair, Fetcher, TokenAmount, JSBI, Price, RoutablePlatform } from '../src'
 import { TEST_TOKENS } from './commons'
 
 describe('Pair', () => {
@@ -17,7 +17,7 @@ describe('Pair', () => {
     it('returns the correct address', () => {
       const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
       const dai = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
-      expect(Pair.getAddress(usdc, dai, SupportedPlatform.SWAPR)).toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
+      expect(Pair.getAddress(usdc, dai, RoutablePlatform.SWAPR)).toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
     })
   })
 
@@ -25,7 +25,7 @@ describe('Pair', () => {
     it('returns the incorrect address', () => {
       const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
       const dai = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'DAI Stablecoin')
-      expect(Pair.getAddress(usdc, dai, SupportedPlatform.UNISWAP)).not.toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
+      expect(Pair.getAddress(usdc, dai, RoutablePlatform.UNISWAP)).not.toEqual('0x0e18852eE5CE266E2Ce6f4844Ba04cd9CD11AF5B')
     })
   })
 
@@ -33,7 +33,7 @@ describe('Pair', () => {
     it('returns the correct address from Uniswap rather than Swapr', () => {
       const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
       const weth = new Token(ChainId.MAINNET, '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 18, 'WETH', 'Wrapped ETH')
-      expect(Pair.getAddress(usdc, weth, SupportedPlatform.UNISWAP)).toEqual('0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc')
+      expect(Pair.getAddress(usdc, weth, RoutablePlatform.UNISWAP)).toEqual('0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc')
     })
   })
 
@@ -41,13 +41,13 @@ describe('Pair', () => {
     it('returns the correct address from Uniswap rather than Swapr', () => {
       const usdc = new Token(ChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 18, 'USDC', 'USD Coin')
       const weth = new Token(ChainId.MAINNET, '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', 18, 'WETH', 'Wrapped ETH')
-      expect(Pair.getAddress(usdc, weth, SupportedPlatform.SUSHISWAP)).toEqual('0x397FF1542f962076d0BFE58eA045FfA2d347ACa0')
+      expect(Pair.getAddress(usdc, weth, RoutablePlatform.SUSHISWAP)).toEqual('0x397FF1542f962076d0BFE58eA045FfA2d347ACa0')
     })
   })
 
   describe('#fetchData', () => {
     it.skip('returns the correct address', async () => {
-      const pairAddress = Pair.getAddress(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY], SupportedPlatform.SWAPR)
+      const pairAddress = Pair.getAddress(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY], RoutablePlatform.SWAPR)
       const pairData = await Fetcher.fetchPairData(Token.WETH[ChainId.RINKEBY], TEST_TOKENS.WEENUS[ChainId.RINKEBY])
       expect(pairData.swapFee).toEqual(JSBI.BigInt(10))
       expect(pairData.protocolFeeDenominator).toEqual(JSBI.BigInt(9))

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -1,5 +1,5 @@
 import JSBI from 'jsbi'
-import { ChainId, ETHER, CurrencyAmount, Pair, Percent, Route, Token, TokenAmount, Trade, TradeType } from '../src'
+import { ChainId, ETHER, CurrencyAmount, Pair, Percent, SupportedPlatform, Route, Token, TokenAmount, Trade, TradeType } from '../src'
 
 describe('Trade', () => {
   const token0 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
@@ -56,6 +56,14 @@ describe('Trade', () => {
     )
     expect(trade.inputAmount.currency).toEqual(token0)
     expect(trade.outputAmount.currency).toEqual(ETHER)
+  })
+  it('has platform value set default to Swapr', () => {
+    const trade = new Trade(
+      new Route([pair_weth_0], ETHER),
+      CurrencyAmount.nativeCurrency(JSBI.BigInt(100), ChainId.MAINNET),
+      TradeType.EXACT_INPUT
+    )
+    expect(trade.platform).toEqual(SupportedPlatform.SWAPR)
   })
 
   describe('#bestTradeExactIn', () => {

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -1,5 +1,5 @@
 import JSBI from 'jsbi'
-import { ChainId, ETHER, CurrencyAmount, Pair, Percent, SupportedPlatform, Route, Token, TokenAmount, Trade, TradeType } from '../src'
+import { ChainId, ETHER, CurrencyAmount, Pair, Percent, RoutablePlatform, Route, Token, TokenAmount, Trade, TradeType } from '../src'
 
 describe('Trade', () => {
   const token0 = new Token(ChainId.MAINNET, '0x0000000000000000000000000000000000000001', 18, 't0')
@@ -63,7 +63,7 @@ describe('Trade', () => {
       CurrencyAmount.nativeCurrency(JSBI.BigInt(100), ChainId.MAINNET),
       TradeType.EXACT_INPUT
     )
-    expect(trade.platform).toEqual(SupportedPlatform.SWAPR)
+    expect(trade.platform).toEqual(RoutablePlatform.SWAPR)
   })
 
   describe('#bestTradeExactIn', () => {


### PR DESCRIPTION
The routing is chain-dependent and the supported platforms as of now are Honeyswap on xDAI and Uniswa/Sushiswap on RInkeby/mainnet.