### PR TITLE
Token icon in token list

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dxswap-core": "git://github.com/levelkdev/dxswap-core.git#v0.3.6",
     "dxswap-periphery": "git://github.com/levelkdev/dxswap-periphery.git#v0.3.7",
     "jsbi": "^3.1.1",
+    "node-fetch": "^2.6.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3",
     "toformat": "^2.0.0"
@@ -49,6 +50,7 @@
     "@ethersproject/solidity": "^5.0.2",
     "@types/big.js": "^4.0.5",
     "@types/jest": "^24.0.25",
+    "@types/node-fetch": "^2.5.8",
     "babel-plugin-transform-jsbi-to-bigint": "^1.3.1",
     "tsdx": "^0.12.3"
   },

--- a/src/entities/token-list.ts
+++ b/src/entities/token-list.ts
@@ -4,6 +4,7 @@ export interface TokenInfo {
   readonly name: string
   readonly decimals: number
   readonly symbol: string
+  readonly logoURI: string
 }
 
 export interface TokenList {

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -39,7 +39,13 @@ export class Token extends Currency {
       'WETH',
       'Wrapped Ether'
     ),
-    [ChainId.XDAI]: new Token(ChainId.XDAI, '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1', 18, 'WETH', 'Wrapped Ether on xDai')
+    [ChainId.XDAI]: new Token(
+      ChainId.XDAI,
+      '0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1',
+      18,
+      'WETH',
+      'Wrapped Ether on xDai'
+    )
   }
 
   public static readonly WSPOA: { [key: number]: Token } = {
@@ -95,6 +101,10 @@ export class Token extends Currency {
 
   public static getNativeWrapper(chainId: ChainId): Token {
     return Token.NATIVE_CURRENCY_WRAPPER[chainId]
+  }
+
+  public static isNativeWrapper(token: Token): boolean {
+    return Token.NATIVE_CURRENCY_WRAPPER[token.chainId].equals(token)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-fetch@^2.5.8":
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.0.26"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.26.tgz#22a3b8a46510da8944b67bfc27df02c34a35331c"
@@ -2311,7 +2319,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3183,6 +3191,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -4700,6 +4717,11 @@ node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Adds the token logo URI to each token item in the token list. The icons are fetched from the CoinGecko token list for mainnet and from the Honeyswap token list for xDai, due to the current shortcomings in out token list implementation (no logo URI/content hash saving implemented).
The icons are then cached locally to avoid multiple token list fetchings.